### PR TITLE
Heap use after free bug fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX=g++
-CXX_FLAGS=-std=c++14 -O3 -Wall -Werror
+CXX_FLAGS=-std=c++14 -O3 -Wall -Werror -g3 -fPIC -fsanitize=address
 CXX_INCLUDE=-I /usr/include -I.
 BOOST_FLAGS=-L/usr/lib/x86_64-linux-gnu -lboost_system -lpthread -lrt
 DEPS=cracl/device.hpp cracl/clock/csac.hpp cracl/clock/firefly.hpp \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX=g++
-CXX_FLAGS=-std=c++14 -O3 -Wall -Werror -g3 -fPIC -fsanitize=address
+CXX_FLAGS=-std=c++14 -O3 -Wall -Werror
 CXX_INCLUDE=-I /usr/include -I.
 BOOST_FLAGS=-L/usr/lib/x86_64-linux-gnu -lboost_system -lpthread -lrt
 DEPS=cracl/device.hpp cracl/clock/csac.hpp cracl/clock/firefly.hpp \

--- a/cracl/device.cpp
+++ b/cracl/device.cpp
@@ -1,7 +1,4 @@
 #include "device.hpp"
- #include <iostream>
- #include <thread>
-
 
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>

--- a/cracl/device.cpp
+++ b/cracl/device.cpp
@@ -131,8 +131,6 @@ std::vector<uint8_t> device::read()
 {
   std::lock_guard<std::mutex> lock(m_mutex);
 
-  m_result_vector.clear();
-
   boost::asio::async_read_until(m_port, m_buf, m_delim,
       boost::bind(&device::read_callback, this,
         boost::asio::placeholders::error,
@@ -174,7 +172,6 @@ std::vector<uint8_t> device::read()
     else if (m_read_status == error)
     {
       m_timer.cancel();
-
       m_port.cancel();
 
       break;
@@ -247,9 +244,9 @@ std::vector<uint8_t> device::read(size_t size)
         break;
       }
     }
-  }
 
-  m_io.reset();
+    m_io.reset();
+  }
 
   return m_result_vector;
 }
@@ -307,9 +304,9 @@ uint8_t device::read_byte()
         break;
       }
     }
-  }
 
-  m_io.reset();
+    m_io.reset();
+  }
 
   return m_result_byte;
 }

--- a/cracl/device.cpp
+++ b/cracl/device.cpp
@@ -1,10 +1,14 @@
 #include "device.hpp"
+ #include <iostream>
+ #include <thread>
+
 
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/asio/serial_port.hpp>
 
 #include <array>
+#include <mutex>
 #include <string>
 
 namespace cracl
@@ -29,6 +33,43 @@ device::device(const std::string& location, size_t baud_rate=115200,
   if (!m_port.is_open())
     throw std::runtime_error(std::string("Could not open port at: "
           + location));
+}
+
+void device::read_byte_callback(const boost::system::error_code& error,
+    const size_t size_transferred)
+{
+  if (size_transferred != 1)
+    std::cout << "\033[1;43m" << std::this_thread::get_id() << " ERROR: size transferred for read byte is " << (int) size_transferred << "! \033[0m" << std::endl;
+
+  if (!error)
+  {
+    if (size_transferred != 1)
+      std::cout << "\033[1;33m" << std::this_thread::get_id() << " Not in error though?? \033[0m" << std::endl;
+
+    m_timer.cancel();
+
+    m_read_status = read_status::finalized;
+    m_read_size = size_transferred;
+  }
+  else
+  {
+#ifdef __APPLE__
+    if (error.value() == 45)
+#elif _WIN32
+    if (error.value() == 995)
+#else
+    if (error.value() == 125)
+#endif
+    {
+      std::cout << "\033[1;31m" << std::this_thread::get_id() << " Timeout error \033[0m" << std::endl;
+      m_read_status = read_status::timeout;
+    }
+    else
+    {
+      std::cout << "\033[1;31m" << std::this_thread::get_id() << " Some other error \033[0m" << std::endl;
+      m_read_status = read_status::error;
+    }
+  }
 }
 
 void device::read_size_callback(const boost::system::error_code& error,
@@ -99,6 +140,8 @@ void device::timeout_callback(const boost::system::error_code& error)
 
 void device::reset()
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
+
   m_port.cancel();
 
   m_io.reset();
@@ -106,6 +149,8 @@ void device::reset()
 
 void device::baud_rate(size_t baud_rate)
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
+
   m_port.set_option(port_base::baud_rate(baud_rate));
 }
 
@@ -121,29 +166,44 @@ void device::timeout(size_t timeout)
 
 void device::write(const char* data, size_t size)
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
+
   boost::asio::write(m_port, boost::asio::buffer(data, size));
+  //m_port.write(boost::asio::buffer(data, size));
 }
 
 void device::write(const std::vector<uint8_t>& data)
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
+
   boost::asio::write(m_port, boost::asio::buffer(data.data(), data.size()));
+  //m_port.write(boost::asio::buffer(data.data(), data.size()));
 }
 
 void device::write(const std::vector<char>& data)
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
+
   boost::asio::write(m_port, boost::asio::buffer(data.data(), data.size()));
+  //m_port.write(boost::asio::buffer(data.data(), data.size()));
 }
 
 void device::write(const std::string& data)
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
+
   boost::asio::write(m_port, boost::asio::buffer(data.c_str(), data.size()));
+  //m_port.write(boost::asio::buffer(data.c_str(), data.size()));
 }
 
 std::vector<uint8_t> device::read()
 {
-  std::vector<uint8_t> result;
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  m_result_vector.clear();
 
   boost::asio::async_read_until(m_port, m_buf, m_delim,
+  //m_port.async_read_until(m_buf, m_delim,
       boost::bind(&device::read_delim_callback, this,
         boost::asio::placeholders::error,
         boost::asio::placeholders::bytes_transferred)
@@ -167,9 +227,9 @@ std::vector<uint8_t> device::read()
 
       std::istream is(&m_buf);
 
-      result.resize(m_read_size);
+      m_result_vector.resize(m_read_size);
 
-      char* data = reinterpret_cast<char*> (result.data());
+      char* data = reinterpret_cast<char*> (m_result_vector.data());
 
       is.read(data, m_read_size);
 
@@ -193,13 +253,16 @@ std::vector<uint8_t> device::read()
 
   m_io.reset();
 
-  return result;
+  return m_result_vector;
 }
 
 std::vector<uint8_t> device::read(size_t size)
 {
-  std::vector<uint8_t> result(size, 0x00);
-  char* data = reinterpret_cast<char*> (result.data());
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  m_result_vector.resize(size);
+
+  char* data = reinterpret_cast<char*> (m_result_vector.data());
 
   if (m_buf.size() > 0)
   {
@@ -216,6 +279,7 @@ std::vector<uint8_t> device::read(size_t size)
   if (size != 0)
   {
     boost::asio::async_read(m_port, boost::asio::buffer(data, size),
+    //m_port.async_read(boost::asio::buffer(data, size),
         boost::bind(&device::read_size_callback, this,
           boost::asio::placeholders::error,
           boost::asio::placeholders::bytes_transferred)
@@ -258,23 +322,27 @@ std::vector<uint8_t> device::read(size_t size)
 
   m_io.reset();
 
-  return result;
+  return m_result_vector;
 }
 
 uint8_t device::read_byte()
 {
-  uint8_t result = 0x00;
+  std::cout << "\033[1;32m" << std::this_thread::get_id() << " read_byte called \033[0m" << std::endl;
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  m_result_byte = 0x00;
 
   if (m_buf.size() > 0)
   {
     std::istream is(&m_buf);
 
-    is.read(reinterpret_cast<char*> (&result), 1);
+    is.read(reinterpret_cast<char*> (&m_result_byte), 1);
   }
   else
   {
-    boost::asio::async_read(m_port, boost::asio::buffer(&result, 1),
-        boost::bind(&device::read_size_callback, this,
+    boost::asio::async_read(m_port, boost::asio::buffer(&m_result_byte, 1),
+    //m_port.async_read(boost::asio::buffer(&result, 1),
+        boost::bind(&device::read_byte_callback, this,
           boost::asio::placeholders::error,
           boost::asio::placeholders::bytes_transferred)
         );
@@ -299,24 +367,29 @@ uint8_t device::read_byte()
       }
       else if (m_read_status == read_status::timeout)
       {
+        std::cout << "\033[1;34m" << std::this_thread::get_id() << " Back in read_byte timeout condition \033[0m" << std::endl;
         m_port.cancel();
 
+        std::cout << "\033[1;34m" << std::this_thread::get_id() << " Port cancelled\033[0m" << std::endl;
         break;
       }
       else if (m_read_status == error)
       {
+        std::cout << "\033[1;34m" << std::this_thread::get_id() << " Back in read_byte error condition \033[0m" << std::endl;
         m_timer.cancel();
 
         m_port.cancel();
 
         break;
       }
+      else
+        std::cout << "\033[1;32m" << std::this_thread::get_id() << " spinning \033[0m" << std::endl;
     }
   }
 
   m_io.reset();
 
-  return result;
+  return m_result_byte;
 }
 
 } // namespace cracl

--- a/cracl/device.hpp
+++ b/cracl/device.hpp
@@ -18,7 +18,6 @@ enum read_status { ongoing, finalized, error, timeout };
 
 class device
 {
-protected:
   size_t m_timeout;
   size_t m_read_size;
   read_status m_read_status;

--- a/cracl/device.hpp
+++ b/cracl/device.hpp
@@ -36,13 +36,7 @@ protected:
   boost::asio::streambuf m_buf;
   boost::asio::deadline_timer m_timer;
 
-  void read_byte_callback(const boost::system::error_code& error,
-      const size_t size_transferred);
-
-  void read_size_callback(const boost::system::error_code& error,
-      const size_t size_transferred);
-
-  void read_delim_callback(const boost::system::error_code& error,
+  void read_callback(const boost::system::error_code& error,
       const size_t size_transferred);
 
   void timeout_callback(const boost::system::error_code& error);

--- a/cracl/device.hpp
+++ b/cracl/device.hpp
@@ -6,6 +6,7 @@
 #include <boost/asio/serial_port.hpp>
 
 #include <array>
+#include <mutex>
 #include <string>
 
 using port_base = boost::asio::serial_port_base;
@@ -17,17 +18,26 @@ enum read_status { ongoing, finalized, error, timeout };
 
 class device
 {
+protected:
   size_t m_timeout;
   size_t m_read_size;
   read_status m_read_status;
 
+  uint8_t m_result_byte;
+  std::vector<uint8_t> m_result_vector;
+
   std::string m_location;
   std::string m_delim;
+
+  std::mutex m_mutex;
 
   boost::asio::io_service m_io;
   boost::asio::serial_port m_port;
   boost::asio::streambuf m_buf;
   boost::asio::deadline_timer m_timer;
+
+  void read_byte_callback(const boost::system::error_code& error,
+      const size_t size_transferred);
 
   void read_size_callback(const boost::system::error_code& error,
       const size_t size_transferred);

--- a/cracl/receiver/ublox_8.cpp
+++ b/cracl/receiver/ublox_8.cpp
@@ -920,41 +920,67 @@ void ublox_8::buffer_messages()
 
   m_current = read_byte();
 
-  while (true)
+  while (m_current != 0x00)
   {
-    if (m_current == 0x00)
-      break;
-    else if (m_current == 0x24  // $ - Start of NMEA/PUBX message
+    if (m_current == 0x24       // $ - Start of NMEA/PUBX message
         || m_current == 0x21)   // ! - Start of encapsulated NMEA message
     {
       message.push_back(m_current);
 
-                                // * - Start of NMEA/PUBX checksum
-      while (m_current >= 0x20 && m_current != 0x2a)
-          message.push_back(m_current = read_byte());
+      while (message.size() < 80 // 82  - Max NMEA length (4: $<content>*##<LF>)
+          && m_current >= 0x20   // ' ' - Min valid char
+          && m_current <= 0x7e   // ~   - Max valid char
+          && m_current != 0x2a)  // *   - Start of NMEA/PUBX checksum
+        message.push_back(m_current = read_byte());
 
-      if (m_current < 0x20)
+      if (message.size() == 80)  // Read too many chars without finding checksum
+        continue;                //   implying incorrect alignment, jump out
+      else if (m_current == 0x00)// Invalid char, also port is empty, jump out
+        continue;                //   will also fail while condition and exit
+      else if (m_current < 0x20  // Invalid char, jump out and read again to
+          || m_current > 0x7e)   //   see if some start byte is recognized
         continue;
+      // else: Parsed reasonable number of potentially valid characters, and
+      //   found what looks like the start of a checksum field. Read two bytes
+      //   for the checksum and one byte for the line ending
 
-      message.push_back(read_byte());
-      message.push_back(read_byte());
+      message.push_back(read_byte()); // First checksum byte
+      message.push_back(read_byte()); // Second checksum byte
+      read_byte();                    // <LF> - just throw it away
 
       m_nmea_buffer.push_back(message);
     }
-    else if (m_current == 0xb5) // μ - Start of UBX message
+    else if (m_current == 0xb5)  // μ - Start of UBX message
     {
       message.push_back(m_current);
-      m_local_buf = read(5);
 
-      uint16_t length = *(reinterpret_cast<uint16_t *> (&m_local_buf[3])) + 2;
+      // Read one byte, expected to be second byte of UBX header
+      m_current = read_byte();
+
+      if (m_current != 0x62)     // Not second byte of UBX header (b), alignment
+        continue;                //   must not be correct, jump out
+      else                       // Else push into message
+        message.push_back(m_current);
+
+      // Read two bytes, expected to be a UBX message class and message ID
+      message.push_back(read_byte());
+      message.push_back(read_byte());
+
+      // Read two bytes, expected to be message length
+      message.push_back(read_byte());
+      message.push_back(read_byte());
+
+      // Interpret length from bytes fetched so far
+      uint16_t length = *(reinterpret_cast<uint16_t *> (&message[4])) + 2;
+
+      if (length > 1024)        // If length is absurdly large assume it's
+        continue;               //   incorrect, jump out
 
       message.reserve(6 + length);
 
-      message.insert(message.end(), m_local_buf.begin(), m_local_buf.end());
-
-      m_local_buf = read(length);
-
-      message.insert(message.end(), m_local_buf.begin(), m_local_buf.end());
+      // Read length number of bytes into message
+      for (size_t i = 0; i < length; ++i)
+        message.push_back(read_byte());
 
       m_ubx_buffer.push_back(message);
     }

--- a/cracl/receiver/ublox_8.hpp
+++ b/cracl/receiver/ublox_8.hpp
@@ -706,6 +706,7 @@ public:
 class ublox_8 : public device
 {
   std::vector<uint8_t> m_local_buf;
+
   std::deque<std::vector<uint8_t>> m_ubx_buffer;
   std::deque<std::vector<uint8_t>> m_nmea_buffer;
 

--- a/cracl/receiver/ublox_8.hpp
+++ b/cracl/receiver/ublox_8.hpp
@@ -705,6 +705,7 @@ public:
 
 class ublox_8 : public device
 {
+  std::vector<uint8_t> m_local_buf;
   std::deque<std::vector<uint8_t>> m_ubx_buffer;
   std::deque<std::vector<uint8_t>> m_nmea_buffer;
 
@@ -782,7 +783,8 @@ public:
 
   std::vector<uint8_t> fetch_ubx();
 
-  std::vector<uint8_t> fetch_ubx(std::string&& msg_class, std::string&& msg_id);
+  std::vector<uint8_t> fetch_ubx(std::string&& msg_class, std::string&& msg_id,
+      bool first_try=true);
 
   void flush_nmea();
 

--- a/cracl/receiver/ublox_8.hpp
+++ b/cracl/receiver/ublox_8.hpp
@@ -705,6 +705,7 @@ public:
 
 class ublox_8 : public device
 {
+  uint8_t m_current;
   std::vector<uint8_t> m_local_buf;
 
   std::deque<std::vector<uint8_t>> m_ubx_buffer;


### PR DESCRIPTION
Rewrite ublox buffer_messages function to add more robust parsing and also avoid the use of device::read(size_t). Use of read(size_t), or possibly the interleaving with read_byte, was causing the heap use after free bug. 

Heap use after free issue seems resolved, but new issue arises in that memory footprint grows without bound. It has probably always been an issue, but not noticed, and also previously much slower due to the bulk reads (as opposed to hundreds of more single byte reads). Possibly related to completion handlers in boost - need to investigate proper long term use of a boost io_service object. 

Should run fine, but grow to around 20GB in 24hours if not killed by the kernel first.