### PR TITLE
Fix unbounded heap consumption bug

### DIFF
--- a/cracl/clock/csac.cpp
+++ b/cracl/clock/csac.cpp
@@ -7,13 +7,13 @@
 namespace cracl
 {
 
-csac::csac(const std::string& location, size_t baud_rate,
-    size_t timeout, size_t char_size, std::string delim,
+csac::csac(const std::string& location, size_t baud_rate, size_t timeout,
+    size_t char_size, std::string delim, size_t max_handlers,
     port_base::parity::type parity,
     port_base::flow_control::type flow_control,
     port_base::stop_bits::type stop_bits)
-  : device (location, baud_rate, timeout, char_size, delim, parity,
-    flow_control, stop_bits)
+  : device (location, baud_rate, timeout, char_size, delim, max_handlers,
+    parity, flow_control, stop_bits)
 { }
 
 void csac::telemetry_header()

--- a/cracl/clock/csac.hpp
+++ b/cracl/clock/csac.hpp
@@ -22,7 +22,7 @@ public:
    * @param A shared_ptr to a communication interface
    */
   csac(const std::string& location, size_t baud_rate=57600, size_t timeout=100,
-      size_t char_size=8, std::string delim="\r\n", size_t max_handlers=1000000,
+      size_t char_size=8, std::string delim="\r\n", size_t max_handlers=100000,
       port_base::parity::type parity=port_base::parity::none,
       port_base::flow_control::type flow_control=port_base::flow_control::none,
       port_base::stop_bits::type stop_bits=port_base::stop_bits::one);

--- a/cracl/clock/csac.hpp
+++ b/cracl/clock/csac.hpp
@@ -21,8 +21,8 @@ public:
    *
    * @param A shared_ptr to a communication interface
    */
-  csac(const std::string& location, size_t baud_rate=57600,
-      size_t timeout=100, size_t char_size=8, std::string delim="\r\n",
+  csac(const std::string& location, size_t baud_rate=57600, size_t timeout=100,
+      size_t char_size=8, std::string delim="\r\n", size_t max_handlers=1000000,
       port_base::parity::type parity=port_base::parity::none,
       port_base::flow_control::type flow_control=port_base::flow_control::none,
       port_base::stop_bits::type stop_bits=port_base::stop_bits::one);

--- a/cracl/clock/firefly.cpp
+++ b/cracl/clock/firefly.cpp
@@ -11,13 +11,13 @@ namespace cracl
 
 std::array<size_t, 5> firefly_baud{ 9600, 19200, 38400, 57600, 115200 };
 
-firefly::firefly(const std::string& location, size_t baud_rate,
-    size_t timeout, size_t char_size, std::string delim,
+firefly::firefly(const std::string& location, size_t baud_rate, size_t timeout,
+    size_t char_size, std::string delim, size_t max_handlers,
     port_base::parity::type parity,
     port_base::flow_control::type flow_control,
     port_base::stop_bits::type stop_bits)
-  : device (location, baud_rate, timeout, char_size, std::move(delim), parity,
-    flow_control, stop_bits)
+  : device (location, baud_rate, timeout, char_size, std::move(delim),
+    max_handlers, parity, flow_control, stop_bits)
 { }
 
 //void firefly::add_pubx_payload(std::vector<char> &message) { }

--- a/cracl/clock/firefly.hpp
+++ b/cracl/clock/firefly.hpp
@@ -30,7 +30,7 @@ class firefly : public device
 public:
   firefly(const std::string& location, size_t baud_rate=115200,
       size_t timeout=100, size_t char_size=8, std::string delim="\r\n\r\n",
-      size_t max_handlers=1000000,
+      size_t max_handlers=100000,
       port_base::parity::type parity=port_base::parity::none,
       port_base::flow_control::type flow_control=port_base::flow_control::none,
       port_base::stop_bits::type stop_bits=port_base::stop_bits::one);

--- a/cracl/clock/firefly.hpp
+++ b/cracl/clock/firefly.hpp
@@ -30,6 +30,7 @@ class firefly : public device
 public:
   firefly(const std::string& location, size_t baud_rate=115200,
       size_t timeout=100, size_t char_size=8, std::string delim="\r\n\r\n",
+      size_t max_handlers=1000000,
       port_base::parity::type parity=port_base::parity::none,
       port_base::flow_control::type flow_control=port_base::flow_control::none,
       port_base::stop_bits::type stop_bits=port_base::stop_bits::one);

--- a/cracl/clock/gpstcxo.cpp
+++ b/cracl/clock/gpstcxo.cpp
@@ -11,13 +11,13 @@ namespace cracl
 
 std::array<size_t, 5> gpsdo_baud{ 9600, 19200, 38400, 57600, 115200 };
 
-gpstcxo::gpstcxo(const std::string& location, size_t baud_rate,
-    size_t timeout, size_t char_size, std::string delim,
+gpstcxo::gpstcxo(const std::string& location, size_t baud_rate, size_t timeout,
+    size_t char_size, std::string delim, size_t max_handlers,
     port_base::parity::type parity,
     port_base::flow_control::type flow_control,
     port_base::stop_bits::type stop_bits)
-  : device (location, baud_rate, timeout, char_size, std::move(delim), parity,
-    flow_control, stop_bits)
+  : device (location, baud_rate, timeout, char_size, std::move(delim),
+    max_handlers, parity, flow_control, stop_bits)
 { }
 
 //void gpstcxo::add_pubx_payload(std::vector<char> &message) { }

--- a/cracl/clock/gpstcxo.hpp
+++ b/cracl/clock/gpstcxo.hpp
@@ -30,6 +30,7 @@ class gpstcxo : public device
 public:
   gpstcxo(const std::string& location, size_t baud_rate=115200,
       size_t timeout=100, size_t char_size=8, std::string delim="\r\n\r\n",
+      size_t max_handlers=1000000,
       port_base::parity::type parity=port_base::parity::none,
       port_base::flow_control::type flow_control=port_base::flow_control::none,
       port_base::stop_bits::type stop_bits=port_base::stop_bits::one);

--- a/cracl/clock/gpstcxo.hpp
+++ b/cracl/clock/gpstcxo.hpp
@@ -30,7 +30,7 @@ class gpstcxo : public device
 public:
   gpstcxo(const std::string& location, size_t baud_rate=115200,
       size_t timeout=100, size_t char_size=8, std::string delim="\r\n\r\n",
-      size_t max_handlers=1000000,
+      size_t max_handlers=100000,
       port_base::parity::type parity=port_base::parity::none,
       port_base::flow_control::type flow_control=port_base::flow_control::none,
       port_base::stop_bits::type stop_bits=port_base::stop_bits::one);

--- a/cracl/device.cpp
+++ b/cracl/device.cpp
@@ -12,14 +12,18 @@
 namespace cracl
 {
 
-device::device(const std::string& location, size_t baud_rate=115200,
-    size_t timeout=100, size_t char_size=8, std::string delim="\r\n",
-    port_base::parity::type parity=port_base::parity::none,
-    port_base::flow_control::type flow_control=port_base::flow_control::none,
-    port_base::stop_bits::type stop_bits=port_base::stop_bits::one)
-  : m_timeout(timeout), m_location(location), m_delim(std::move(delim)),
-    m_io(), m_port(m_io), m_timer(m_io)
+device::device(const std::string& location, size_t baud_rate, size_t timeout,
+    size_t char_size, std::string delim,size_t max_handlers,
+    port_base::parity::type parity, port_base::flow_control::type flow_control,
+    port_base::stop_bits::type stop_bits)
+  : m_timeout(timeout), m_max_handlers(max_handlers), m_location(location),
+    m_delim(std::move(delim)), m_io(), m_port(m_io), m_timer(m_io)
 {
+  // Create a shared pointer to this instance so that we can track the number of
+  //   handlers stored by io_service, and destruct/reconstruct m_io as needed
+  //   to manage memory usage. The use count should always be >1 as the instance
+  //   will own a pointer to itself, but pass a null destructor to emphasize
+  //   that the shared_ptr is used for counting and not management.
   m_this = std::shared_ptr<device>(this, [=](device* d) { });
 
   m_port.open(m_location);
@@ -76,7 +80,7 @@ void device::timeout_callback(const boost::system::error_code& error)
     m_read_status = read_status::error;
 }
 
-void device::reset()
+void device::flush_handlers()
 {
   std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -94,9 +98,14 @@ void device::reset()
   m_port.get_option(flow_control);
   m_port.get_option(stop_bits);
 
+  // Manually call destructor and perform in-place new construction to manage
+  //   lifecycle. Destructing io_serice results in the destruction of stored
+  //   handlers from previous read and write operations, which would otherwise
+  //   grow without bound
   m_io.~io_service();
   new (&m_io) boost::asio::io_service();
 
+  // Manually destruct and re-construct port with new io_service
   m_port.~basic_serial_port();
   new (&m_port) boost::asio::serial_port(m_io);
 
@@ -112,6 +121,7 @@ void device::reset()
     throw std::runtime_error(std::string("Could not re-open port at: "
           + m_location));
 
+  // Manually destruct and re-construct timer with new io_service
   m_timer.~basic_deadline_timer();
   new (&m_timer) boost::asio::deadline_timer(m_io);
 }
@@ -135,13 +145,20 @@ void device::timeout(size_t timeout)
 
 void device::write(const char* data, size_t size)
 {
+  if (handler_count() > m_max_handlers)
+    flush_handlers();
+
   std::lock_guard<std::mutex> lock(m_mutex);
+
 
   boost::asio::write(m_port, boost::asio::buffer(data, size));
 }
 
 void device::write(const std::vector<uint8_t>& data)
 {
+  if (handler_count() > m_max_handlers)
+    flush_handlers();
+
   std::lock_guard<std::mutex> lock(m_mutex);
 
   boost::asio::write(m_port, boost::asio::buffer(data.data(), data.size()));
@@ -149,6 +166,9 @@ void device::write(const std::vector<uint8_t>& data)
 
 void device::write(const std::vector<char>& data)
 {
+  if (handler_count() > m_max_handlers)
+    flush_handlers();
+
   std::lock_guard<std::mutex> lock(m_mutex);
 
   boost::asio::write(m_port, boost::asio::buffer(data.data(), data.size()));
@@ -156,6 +176,9 @@ void device::write(const std::vector<char>& data)
 
 void device::write(const std::string& data)
 {
+  if (handler_count() > m_max_handlers)
+    flush_handlers();
+
   std::lock_guard<std::mutex> lock(m_mutex);
 
   boost::asio::write(m_port, boost::asio::buffer(data.c_str(), data.size()));
@@ -163,6 +186,9 @@ void device::write(const std::string& data)
 
 std::vector<uint8_t> device::read()
 {
+  if (handler_count() > m_max_handlers)
+    flush_handlers();
+
   std::lock_guard<std::mutex> lock(m_mutex);
 
   boost::asio::async_read_until(m_port, m_buf, m_delim,
@@ -219,6 +245,9 @@ std::vector<uint8_t> device::read()
 
 std::vector<uint8_t> device::read(size_t size)
 {
+  if (handler_count() > m_max_handlers)
+    flush_handlers();
+
   std::lock_guard<std::mutex> lock(m_mutex);
 
   m_result_vector.resize(size);
@@ -287,6 +316,9 @@ std::vector<uint8_t> device::read(size_t size)
 
 uint8_t device::read_byte()
 {
+  if (handler_count() > m_max_handlers)
+    flush_handlers();
+
   std::lock_guard<std::mutex> lock(m_mutex);
 
   m_result_byte = 0x00;

--- a/cracl/device.hpp
+++ b/cracl/device.hpp
@@ -6,6 +6,7 @@
 #include <boost/asio/serial_port.hpp>
 
 #include <array>
+#include <memory>
 #include <mutex>
 #include <string>
 
@@ -29,6 +30,8 @@ class device
   std::string m_delim;
 
   std::mutex m_mutex;
+
+  std::shared_ptr<device> m_this;
 
   boost::asio::io_service m_io;
   boost::asio::serial_port m_port;

--- a/cracl/device.hpp
+++ b/cracl/device.hpp
@@ -21,6 +21,7 @@ class device
 {
   size_t m_timeout;
   size_t m_read_size;
+  size_t m_max_handlers;
   read_status m_read_status;
 
   uint8_t m_result_byte;
@@ -43,14 +44,21 @@ class device
 
   void timeout_callback(const boost::system::error_code& error);
 
-public:
-  device(const std::string& location, size_t baud_rate,
-      size_t timeout, size_t char_size, std::string delim,
-      port_base::parity::type parity,
-      port_base::flow_control::type flow_control,
-      port_base::stop_bits::type stop_bits);
+  /* @brief Private function to deconstruct and reconstruct io_service,
+   *        serial_port, and deadline_timer so that the lifecycle of Boost
+   *        handlers can be managed to control heap memory usage.
+   */
+  void flush_handlers();
 
-  void reset();
+public:
+  device(const std::string& location, size_t baud_rate=115200,
+      size_t timeout=100, size_t char_size=8, std::string delim="\r\n",
+      size_t max_handlers=1000000,
+      port_base::parity::type parity=port_base::parity::none,
+      port_base::flow_control::type flow_control=port_base::flow_control::none,
+      port_base::stop_bits::type stop_bits=port_base::stop_bits::one);
+
+  inline size_t handler_count() { return m_this.use_count() - 1; };
 
   void baud_rate(size_t baud_rate);
 

--- a/cracl/device.hpp
+++ b/cracl/device.hpp
@@ -53,7 +53,7 @@ class device
 public:
   device(const std::string& location, size_t baud_rate=115200,
       size_t timeout=100, size_t char_size=8, std::string delim="\r\n",
-      size_t max_handlers=1000000,
+      size_t max_handlers=100000,
       port_base::parity::type parity=port_base::parity::none,
       port_base::flow_control::type flow_control=port_base::flow_control::none,
       port_base::stop_bits::type stop_bits=port_base::stop_bits::one);

--- a/cracl/receiver/ublox_8.cpp
+++ b/cracl/receiver/ublox_8.cpp
@@ -1044,7 +1044,6 @@ std::vector<uint8_t> ublox_8::fetch_ubx(std::string&& msg_class,
         && m_ubx_buffer[i][3] == msg_map.at(msg_class).second.at(msg_id))
       break;
 
-
   if (i != m_ubx_buffer.size()) // If found, fetch and erase from buffer
   {
     temp = m_ubx_buffer[i];

--- a/cracl/receiver/ublox_8.cpp
+++ b/cracl/receiver/ublox_8.cpp
@@ -15,6 +15,21 @@ namespace cracl
 namespace ubx
 {
 
+/* @brief Compute 8-bit Fletcher checksum and compare it to values in a given
+ *        message
+ */
+bool valid_checksum(std::vector<uint8_t>& message)
+{
+  size_t i;
+  uint8_t check_a = 0;
+  uint8_t check_b = 0;
+
+  for (i = 2; i < message.size() - 2; ++i)
+    check_b += (check_a += message[i]);
+
+  return (check_a == message[i] && check_b == message[i + 1]);
+}
+
 namespace mon
 {
 

--- a/cracl/receiver/ublox_8.cpp
+++ b/cracl/receiver/ublox_8.cpp
@@ -15,18 +15,6 @@ namespace cracl
 namespace ubx
 {
 
-bool valid_checksum(std::vector<uint8_t>& message)
-{
-  size_t i;
-  uint8_t check_a = 0;
-  uint8_t check_b = 0;
-
-  for (i = 2; i < message.size() - 2; ++i)
-    check_b += (check_a += message[i]);
-
-  return (check_a == message[i] && check_b == message[i + 1]);
-}
-
 namespace mon
 {
 
@@ -905,13 +893,13 @@ bool rawx::type(std::vector<uint8_t>& message)
 
 } // namespace ubx
 
-ublox_8::ublox_8(const std::string& location, size_t baud_rate,
-    size_t timeout, size_t char_size, std::string delim,
+ublox_8::ublox_8(const std::string& location, size_t baud_rate, size_t timeout,
+    size_t char_size, std::string delim, size_t max_handlers,
     port_base::parity::type parity,
     port_base::flow_control::type flow_control,
     port_base::stop_bits::type stop_bits)
   : device (location, baud_rate, timeout, char_size, std::string(delim),
-    parity, flow_control, stop_bits)
+    max_handlers, parity, flow_control, stop_bits)
 { }
 
 void ublox_8::buffer_messages()
@@ -920,6 +908,7 @@ void ublox_8::buffer_messages()
 
   m_current = read_byte();
 
+  // Read byte by byte until port returns empty/timeout occurs
   while (m_current != 0x00)
   {
     if (m_current == 0x24       // $ - Start of NMEA/PUBX message
@@ -1034,18 +1023,20 @@ std::vector<uint8_t> ublox_8::fetch_ubx(std::string&& msg_class,
   if (m_ubx_buffer.empty())
     buffer_messages();
 
+  // Look for message with header matching request
   for (i = 0; i < m_ubx_buffer.size(); ++i)
     if (m_ubx_buffer[i][2] == msg_map.at(msg_class).first
         && m_ubx_buffer[i][3] == msg_map.at(msg_class).second.at(msg_id))
       break;
 
-  if (i != m_ubx_buffer.size())
+
+  if (i != m_ubx_buffer.size()) // If found, fetch and erase from buffer
   {
     temp = m_ubx_buffer[i];
 
     m_ubx_buffer.erase(m_ubx_buffer.begin() + i);
   }
-  else if (first_try)
+  else if (first_try) // If not found and first try, double check for new msgs
   {
     buffer_messages();
 
@@ -1068,6 +1059,8 @@ void ublox_8::flush_ubx()
 
 void ublox_8::disable_nmea()
 {
+  // Disable all NMEA message types (0) for all ports
+  // RATE - NMEA TYPE - DDC - USART1 - USART2 - USB - SPI - reserved
   pubx_send("RATE", "DTM", 0, 0, 0, 0, 0, 0);
   pubx_send("RATE", "GLL", 0, 0, 0, 0, 0, 0);
   pubx_send("RATE", "GNS", 0, 0, 0, 0, 0, 0);

--- a/cracl/receiver/ublox_8.hpp
+++ b/cracl/receiver/ublox_8.hpp
@@ -771,7 +771,7 @@ class ublox_8 : public device
 public:
   ublox_8(const std::string& location, size_t baud_rate=9600,
       size_t timeout=500, size_t char_size=8, std::string delim="\r\n",
-      size_t max_handlers=1000000,
+      size_t max_handlers=100000,
       port_base::parity::type parity=port_base::parity::none,
       port_base::flow_control::type flow_control=port_base::flow_control::none,
       port_base::stop_bits::type stop_bits=port_base::stop_bits::one);

--- a/cracl/receiver/ublox_8.hpp
+++ b/cracl/receiver/ublox_8.hpp
@@ -245,21 +245,6 @@ const std::map<std::string, std::pair<uint8_t, std::map<std::string, uint8_t>>>
 namespace ubx
 {
 
-  /* @brief Compute 8-bit Fletcher checksum and compare it to values in a given
-   *        message
-   */
-  bool valid_checksum(std::vector<uint8_t>& message)
-  {
-    size_t i;
-    uint8_t check_a = 0;
-    uint8_t check_b = 0;
-
-    for (i = 2; i < message.size() - 2; ++i)
-      check_b += (check_a += message[i]);
-
-    return (check_a == message[i] && check_b == message[i + 1]);
-  }
-
 namespace mon
 {
 

--- a/cracl/receiver/ublox_8.hpp
+++ b/cracl/receiver/ublox_8.hpp
@@ -817,7 +817,7 @@ public:
     a = (checksum & 0xf0) >> 4;
     b = checksum & 0x0f;
 
-    // Convert numberical values to plaintext hexadecimal
+    // Convert values to plaintext hexadecimal
     a += a < 0xa ? '0' : ('A' - 0xa);
     b += b < 0xa ? '0' : ('A' - 0xa);
 


### PR DESCRIPTION
Modify device reset to explicitly call io_service destructor and then in-place new a new io_service object (along with reconstructing the serial port and deadline timer). This serves the purpose of deleting all handlers associated with io_service object, which would otherwise accumulate indefinitely and consume massive amounts of heap memory.

Also use shared pointer for callbacks in async operations